### PR TITLE
Fix production db config

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,5 +50,6 @@ test:
 production:
   <<: *default
   database: freemarket_sample_57a_production
-  username: freemarket_sample_57a
-  password: <%= ENV['FREEMARKET_SAMPLE_57A_DATABASE_PASSWORD'] %>
+  username: root
+  password: <%= Rails.application.credentials.database_password %>
+  socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
# what
本番環境で、アプリケーションサーバーとデータベースサーバーを接続できるよう、`database.yml`の設定を変更
- 秘密情報は`credentilas.yml.enc`で保管
- mysqlのpasswordについては、変数`database_password`で設定

※ 参考：[Rails5\.2から追加された credentials\.yml\.enc のキホン \- Qiita](https://qiita.com/NaokiIshimura/items/2a179f2ab910992c4d39)

# why
本番環境構築のため