### PR TITLE
Fix capistrano

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -26,6 +26,7 @@ set :repo_url, "git@github.com:Plum0207/freemarket_sample_57a.git"
 # Default value for linked_dirs is []
 # append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'public/uploads')
+set :linked_files, fetch(:linked_files, []).push('config/master.key')
 set :rbenv_type, :user
 set :rbenv_ruby, '2.5.1'
 # Default value for default_env is {}
@@ -39,7 +40,7 @@ set :rbenv_ruby, '2.5.1'
 
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure
-set :ssh_options, auth_methods: ['publickey'],keys: ['~/.ssh/FreeMarket57a.pem']
+set :ssh_options, auth_methods: ['publickey'], keys: ['~/.ssh/FreeMarket57a.pem']
 set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }
 set :keep_releases, 5

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
+  config.require_master_key = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.


### PR DESCRIPTION
# what
自動デプロイでmaster.keyを読み取るように設定

# why
自動デプロイ時に、secret_key_baseが読み取れないエラーが発生しているため