### PR TITLE
Add basic_auth env

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -66,3 +66,8 @@ namespace :deploy do
   before :starting, 'deploy:upload'
   after :finishing, 'deploy:cleanup'
 end
+
+set :default_env,{
+  BASIC_AUTH_USER: ENV["BASIC_AUTH_USER"]
+  BASIC_AUTH_PASSWORD: ENV["BASIC_AUTH_PASSWORD"]
+}

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -7,7 +7,8 @@
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}
 server '176.32.81.244', user: 'ec2-user', roles: %w{app db web}
-
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
 
 # role-based syntax
 # ==================


### PR DESCRIPTION
# what
- Unicornで動作する環境を`production`と認識するように指定
- capistranoで構築した本番環境で環境変数を使用するため、deploy.rbに環境変数を記載

# why
BASIC認証を`production`環境で有効にするため