### PR TITLE
Fix syntax error

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -67,7 +67,7 @@ namespace :deploy do
   after :finishing, 'deploy:cleanup'
 end
 
-set :default_env,{
-  BASIC_AUTH_USER: ENV["BASIC_AUTH_USER"]
+set :default_env, {
+  BASIC_AUTH_USER: ENV["BASIC_AUTH_USER"],
   BASIC_AUTH_PASSWORD: ENV["BASIC_AUTH_PASSWORD"]
 }


### PR DESCRIPTION
# what 
deploy.rbのsyntax-errorを修正
- スペースの追加
- カンマの追加

# why
自動デプロイをしたところ、syntax errorが出たため