### PR TITLE
Fix DB design

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@
 |Column|Type|Options|
 |------|----|-------|
 |user_id|references|null: false, foreign_key: true|
-|customer_id|integer|
-|card_id|integer|
 
 ### Association
 - belongs_to :user
@@ -75,7 +73,7 @@
 |prefecture_from|string|null: false|
 |shipping-date|string|null: false|
 |price|integer|null: false|
-|buyer-id|references|null: false, foreign_key: true|
+|buyer-id|references|foreign_key: true|
 
 ### Association
 - belongs_to :user


### PR DESCRIPTION
# what
READMEに記載しているDB設計を修正  
1.   itemsテーブルのbuyer-idカラムから`null:false`を削除
2.  cardsテーブルのカラムをusers_idのみに修正

# why
1. 出品中の商品には、購入者(buyer)がいないため
2. payjpを利用する方式に合わせて修正