### PR TITLE
add-current_user/items#create

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -61,7 +61,7 @@ class ItemsController < ApplicationController
       :prefecture_from, 
       :shipping_date, 
       :price,
-    ).merge(brand_id: @brand.id)
+    ).merge(brand_id: @brand.id, seller_id: current_user.id)
   end
 
   def images_params


### PR DESCRIPTION
# what
itemsコントローラーのcreateアクションで使用するストロングパラメーターに、`current_user.id`を追加

# why
itemを保存するときに、出品したユーザーidも同時に保存するため