### PR TITLE
Modify DBdesign for item purchase

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 |prefecture_from|integer|null: false|
 |shipping_date|integer|null: false|
 |price|integer|null: false|
+|status|integer|null: false|
 
 ### Association
 - belongs_to :user

--- a/db/migrate/20191222060201_add_status_to_items.rb
+++ b/db/migrate/20191222060201_add_status_to_items.rb
@@ -1,0 +1,6 @@
+class AddStatusToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :status, :integer
+    change_column_null :items, :status, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_02_134349) do
+ActiveRecord::Schema.define(version: 2019_12_22_060201) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 2019_12_02_134349) do
     t.integer "price", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", null: false
     t.index ["brand_id"], name: "index_items_on_brand_id"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["seller_id"], name: "index_items_on_seller_id"


### PR DESCRIPTION
# what
- DB設計の見直し(readme.mdの修正)
- items テーブルにstatusカラムを追加
  - enumsを用いて、商品の状態を管理します（なので、integer型）

# why
出品したアイテムについて
- 出品中
- 出品停止中
- 交渉中
- 完売

を管理するカラムが存在しなかったため
