### PR TITLE
create_breadcrumb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ gem 'rails-i18n'
 gem 'ancestry'
 gem 'payjp'
 gem 'dotenv-rails'
+gem 'gretel'
 
 group :production do
   gem 'unicorn', '5.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -376,6 +378,7 @@ DEPENDENCIES
   faker
   fog-aws
   font-awesome-rails
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -37,6 +37,9 @@
 // footer
 @import 'module/footer';
 
+// breadcrumbs
+@import 'module/breadcrumbs';
+
 // sell-button
 @import 'module/sell-button';
 

--- a/app/assets/stylesheets/module/_breadcrumbs.scss
+++ b/app/assets/stylesheets/module/_breadcrumbs.scss
@@ -1,0 +1,26 @@
+.breadcrumbs {
+    position: relative;
+    border-top: 1px solid #eee;
+    box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
+    background-color: $white;
+    font-size: 14px;
+    height: 48px;
+    line-height: 44px;
+    padding: 0 210px;
+    z-index: 1;
+    a {
+      color: $black;
+      font-size: 14px;
+      margin-right: 5px;
+    }
+    &__list {
+      color: $darkgray;
+      font-size: 20px;
+    }
+    .current {
+      color: $black;
+      font-size: 14px;
+      font-weight: 600;
+      margin-left: 2px;
+    }
+  }

--- a/app/views/cards/confirmation.html.haml
+++ b/app/views/cards/confirmation.html.haml
@@ -1,4 +1,7 @@
 = render "shared/header"
+- breadcrumb :card
+= render 'shared/breadcrumbs'
+
 .wrapper
   .container-mypage
 

--- a/app/views/shared/_breadcrumbs.html.haml
+++ b/app/views/shared/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs pretext: "", separator: " &rsaquo; ", class: "breadcrumbs__list"

--- a/app/views/users/identification.html.haml
+++ b/app/views/users/identification.html.haml
@@ -1,5 +1,6 @@
 = render "shared/header"
--# - breadcrumb :identification
+- breadcrumb :identification
+= render 'shared/breadcrumbs'
 
 .wrapper
   .container-mypage

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,4 +1,7 @@
 = render "shared/header"
+- breadcrumb :mypage
+= render 'shared/breadcrumbs'
+
 .wrapper
   .container-mypage
     = render"users/side_bar"  

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,5 +1,7 @@
 = render "shared/header"
--# - breadcrumb :logout
+- breadcrumb :logout
+= render 'shared/breadcrumbs'
+
 .mypage_container
   .left-container
     .left-content

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -1,5 +1,7 @@
 = render "shared/header"
--# -breadcrumb :profile
+- breadcrumb :profile
+= render 'shared/breadcrumbs'
+
 .wrapper
   .container-mypage
 

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,28 @@
+crumb :root do
+  link "Home", root_path
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,28 +1,28 @@
 crumb :root do
-  link "Home", root_path
+  link "メルカリ", root_path
 end
 
-# crumb :projects do
-#   link "Projects", projects_path
-# end
+# マイページ
+crumb :mypage do
+  link "マイページ", users_path
+end
 
-# crumb :project do |project|
-#   link project.name, project_path(project)
-#   parent :projects
-# end
+crumb :profile do
+  link "プロフィール", profile_users_path
+  parent :mypage
+end
 
-# crumb :project_issues do |project|
-#   link "Issues", project_issues_path(project)
-#   parent :project, project
-# end
+crumb :card do
+  link "支払い方法", confirmation_cards_path
+  parent :mypage
+end
 
-# crumb :issue do |issue|
-#   link issue.title, issue_path(issue)
-#   parent :project_issues, issue.project
-# end
+crumb :identification do
+  link "本人情報の登録", identification_users_path
+  parent :mypage
+end
 
-# If you want to split your breadcrumbs configuration over multiple files, you
-# can create a folder named `config/breadcrumbs` and put your configuration
-# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
-# folder are loaded and reloaded automatically when you change them, just like
-# this file (`config/breadcrumbs.rb`).
+crumb :logout do
+  link "ログアウト", logout_users_path
+  parent :mypage
+end


### PR DESCRIPTION
# What
パンくずリストの実装

# Why
ユーザーがサイト上のどこにいるのか視覚的にわかり易くすることで、ユーザビリティを向上するため。

# 画面キャプチャー（gyazo)
[マイページ画面](https://gyazo.com/20cbe0d07365f1c614b8211b2a30765b)