### PR TITLE
Fix definitions of payjp ap ikey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@
 app/assets/.DS_Store
 /.env
 
-# Ignore master key for decrypting credentials and more.
-/config/master-development.key
+
+

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,8 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'
   gem 'faker'
-  gem 'rails-env-credentials'
+  gem 'dotenv-rails'
+
 end
 
 group :development do
@@ -84,7 +85,6 @@ gem 'enum_help'
 gem 'rails-i18n'
 gem 'ancestry'
 gem 'payjp'
-gem 'dotenv-rails'
 gem 'gretel'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,8 +249,6 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-env-credentials (0.1.4)
-      rails (>= 5.2.0.rc1)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     rails-i18n (5.1.3)
@@ -392,7 +390,6 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.3)
   rails-controller-testing
-  rails-env-credentials
   rails-i18n
   rspec-rails
   sass-rails (~> 5.0)

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -10,7 +10,12 @@ class CardsController < ApplicationController
   end
 
   def create
-    Payjp.api_key = Rails.application.credentials.payjp[:payjp_private_key]
+    if Rails.env.development? || Rails.env.test?
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+    else
+      Payjp.api_key = Rails.application.credentials.payjp[:payjp_private_key]
+    end
+    
     if params['payjp-token'].blank?
       redirect_to action: "new"
     else
@@ -38,6 +43,11 @@ class CardsController < ApplicationController
   end
 
   def show
+    if Rails.env.development? || Rails.env.test?
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+    else
+      Payjp.api_key = Rails.application.credentials.payjp[:payjp_private_key]
+    end
     if @card.blank?
       redirect_to action: "confirmation"
     else


### PR DESCRIPTION
# what
payjpのAPIキーについて、
呼び出し元を本番環境とそのほかの環境で変更するよう
条件分岐を追加
- 本番環境：credentialsを使用
- 開発環境・テスト環境：ENVを使用（gem'dotenv-rails'を使用）

# why
- credentialsは、本番環境にしか適用されず、開発環境及びテスト環境において、PAYJPを使用したカード登録ができなくなったため
- これまではgem'rails-env-credentials'を使用し、開発環境でもcredentialsを使って、APIキーを呼び出していたが、他チーム員で実行できないエラーが発生してしまうため
