### PR TITLE
Update-items/show-page-add-buttons

### DIFF
--- a/app/assets/stylesheets/module/items/_show.scss
+++ b/app/assets/stylesheets/module/items/_show.scss
@@ -370,6 +370,7 @@
                   top: 20px;
                   font-size: 26px;
                   line-height: 26px;
+                  font-weight: 600;
                   transform: rotate(-45deg);
                   color:$white;
                 }

--- a/app/assets/stylesheets/module/items/_show.scss
+++ b/app/assets/stylesheets/module/items/_show.scss
@@ -39,6 +39,30 @@
             }
           }
         }
+        &__sold-out-badge{
+          &__caption{
+            position: absolute;
+            top: 24px;
+            left: 0;
+            z-index: 2;
+            color:$white;
+            transform: rotate(-45deg);
+            font-size: 28px;
+            line-height: 28px;
+            font-weight: 600;
+          }
+          &:after{
+            border-width: 120px 120px 0 0;
+            border-color: $red transparent transparent;
+            border-style: solid;
+            display: block;
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            z-index: 1;
+          }
+        }
       }
       table,th,tr{
         border: 1px solid #f5f5f5;

--- a/app/assets/stylesheets/module/items/_show.scss
+++ b/app/assets/stylesheets/module/items/_show.scss
@@ -106,6 +106,18 @@
         font-size: 16px;
       }
     }
+    &__buy-btn{
+      display: block;
+      height: 60px;
+      background: $red;
+      margin-top: 16px;
+      color: $white;
+      font-size: 24px;
+      font-weight: 600;
+      line-height: 60px;
+      text-align: center;
+      text-decoration: none;
+    }
     &__item-description{
       padding: 32px 0 0;
       p{

--- a/app/assets/stylesheets/module/items/_show.scss
+++ b/app/assets/stylesheets/module/items/_show.scss
@@ -172,6 +172,36 @@
       }
     }
   }
+  &__edit-btns-container{
+    width: 700px;
+    margin: 0 auto;
+    &__btns-box{
+      margin: 24px 0;
+      background-color: $white;
+      padding: 8px 16px;
+      &__btn{
+        margin: 16px 0;
+        display: block;
+        line-height: 48px;
+        font-size: 14px;
+        text-align: center;
+        text-decoration: none;
+        color: $white;
+        &__edit-btn{
+          background-color: $red;
+          border: 1px solid $red;
+        }
+        &__stop-btn, &__delete-btn{
+          background-color: $gray;
+          border: 1px solid$gray;
+        }
+      }
+      &__text{
+        font-size: 16px;
+        text-align: center;
+      }
+    }
+  }
   &__message{
     margin: 8px auto;
     &__message-container{

--- a/app/assets/stylesheets/module/items/_show.scss
+++ b/app/assets/stylesheets/module/items/_show.scss
@@ -117,6 +117,10 @@
       line-height: 60px;
       text-align: center;
       text-decoration: none;
+      &__disabled{
+        background: $darkgray;
+        cursor: not-allowed;
+      }
     }
     &__item-description{
       padding: 32px 0 0;

--- a/app/views/items/_items-box.html.haml
+++ b/app/views/items/_items-box.html.haml
@@ -2,9 +2,8 @@
   =link_to item_path(item), class: "item-detail__items-in-user-profile__items-box-container__content__items-box__link" do
     %figure.item-detail__items-in-user-profile__items-box-container__content__items-box__link__photo
       = image_tag item.images[0].image.url, alt: 'main-photo', height: '220px', width: '220px'
-      -# 別ブランチでconditonカラムを増設後、条件分岐を設定予定
-      -# %figcaption.item-detail__items-in-user-profile__items-box-container__content__items-box__link__photo__sold-out-badge
-      -#   .item-detail__items-in-user-profile__items-box-container__content__items-box__link__photo__sold-out-badge__caption SOLD
+      %figcaption.item-detail__items-in-user-profile__items-box-container__content__items-box__link__photo__sold-out-badge
+        .item-detail__items-in-user-profile__items-box-container__content__items-box__link__photo__sold-out-badge__caption SOLD
     .item-detail__items-in-user-profile__items-box-container__content__items-box__link__body
       %h3.item-detail__items-in-user-profile__items-box-container__content__items-box__link__body__name
         = item.name

--- a/app/views/items/_items-box.html.haml
+++ b/app/views/items/_items-box.html.haml
@@ -2,7 +2,7 @@
   =link_to item_path(item), class: "item-detail__items-in-user-profile__items-box-container__content__items-box__link" do
     %figure.item-detail__items-in-user-profile__items-box-container__content__items-box__link__photo
       = image_tag item.images[0].image.url, alt: 'main-photo', height: '220px', width: '220px'
-      -if item.status == "sold"
+      -if item.sold?
         %figcaption.item-detail__items-in-user-profile__items-box-container__content__items-box__link__photo__sold-out-badge
           .item-detail__items-in-user-profile__items-box-container__content__items-box__link__photo__sold-out-badge__caption SOLD
     .item-detail__items-in-user-profile__items-box-container__content__items-box__link__body

--- a/app/views/items/_items-box.html.haml
+++ b/app/views/items/_items-box.html.haml
@@ -2,8 +2,9 @@
   =link_to item_path(item), class: "item-detail__items-in-user-profile__items-box-container__content__items-box__link" do
     %figure.item-detail__items-in-user-profile__items-box-container__content__items-box__link__photo
       = image_tag item.images[0].image.url, alt: 'main-photo', height: '220px', width: '220px'
-      %figcaption.item-detail__items-in-user-profile__items-box-container__content__items-box__link__photo__sold-out-badge
-        .item-detail__items-in-user-profile__items-box-container__content__items-box__link__photo__sold-out-badge__caption SOLD
+      -if item.status == "sold"
+        %figcaption.item-detail__items-in-user-profile__items-box-container__content__items-box__link__photo__sold-out-badge
+          .item-detail__items-in-user-profile__items-box-container__content__items-box__link__photo__sold-out-badge__caption SOLD
     .item-detail__items-in-user-profile__items-box-container__content__items-box__link__body
       %h3.item-detail__items-in-user-profile__items-box-container__content__items-box__link__body__name
         = item.name

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -13,6 +13,8 @@
           - @item.images.each do |image|
             .item-detail__top-container__main-content__photoshow__thumnail-photos__thumnail-photo.thumnail-photo
               = image_tag image.image.url, alt: 'thumnail-photo', height: '60px', width: '60px'
+        .item-detail__top-container__main-content__photoshow__sold-out-badge
+        .item-detail__top-container__main-content__photoshow__sold-out-badge__caption SOLD
       %table.item-detail__top-container__main-content__table
         %tr
           %th 出品者

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -13,8 +13,9 @@
           - @item.images.each do |image|
             .item-detail__top-container__main-content__photoshow__thumnail-photos__thumnail-photo.thumnail-photo
               = image_tag image.image.url, alt: 'thumnail-photo', height: '60px', width: '60px'
-        .item-detail__top-container__main-content__photoshow__sold-out-badge
-        .item-detail__top-container__main-content__photoshow__sold-out-badge__caption SOLD
+        - if @item.status == "sold"
+          .item-detail__top-container__main-content__photoshow__sold-out-badge
+          .item-detail__top-container__main-content__photoshow__sold-out-badge__caption SOLD
       %table.item-detail__top-container__main-content__table
         %tr
           %th 出品者

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -13,7 +13,7 @@
           - @item.images.each do |image|
             .item-detail__top-container__main-content__photoshow__thumnail-photos__thumnail-photo.thumnail-photo
               = image_tag image.image.url, alt: 'thumnail-photo', height: '60px', width: '60px'
-        - if @item.status == "sold"
+        - if @item.sold?
           .item-detail__top-container__main-content__photoshow__sold-out-badge
           .item-detail__top-container__main-content__photoshow__sold-out-badge__caption SOLD
       %table.item-detail__top-container__main-content__table

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -66,11 +66,12 @@
         = @item.price.to_s(:delimited)
       %span.item-detail__top-container__price-box__tax &#040;税込&#041;
       %span.item-detail__top-container__price-box__shipping-fee 送料込み
-    - if @item.status == "sale"
-      = link_to '購入画面に進む', buy_item_path, class: 'item-detail__top-container__buy-btn'
-    - elsif @item.status == "sold"
-      .item-detail__top-container__buy-btn.item-detail__top-container__buy-btn__disabled
-        売り切れました
+    - unless @user == current_user
+      - if @item.status == "sale"
+        = link_to '購入画面に進む', buy_item_path, class: 'item-detail__top-container__buy-btn'
+      - elsif @item.status == "sold"
+        .item-detail__top-container__buy-btn.item-detail__top-container__buy-btn__disabled
+          売り切れました
     .item-detail__top-container__item-description
       %p
         =@item.description

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -89,6 +89,12 @@
         =link_to "https://www.mercari.com/jp/safe/description/", target: '_blank' do
           =fa_icon 'lock'
           %span あんしん・あんぜんへの取り組み
+  .item-detail__edit-btns-container
+    .item-detail__edit-btns-container__btns-box
+      =link_to '商品の編集', edit_item_path, class: 'item-detail__edit-btns-container__btns-box__btn item-detail__edit-btns-container__btns-box__btn__edit-btn'
+      %p.item-detail__edit-btns-container__btns-box__text or
+      =link_to '出品を一旦停止する', '', class: 'item-detail__edit-btns-container__btns-box__btn item-detail__edit-btns-container__btns-box__btn__stop-btn'
+      =link_to 'この商品を削除する', item_path, method: :delete, class: 'item-detail__edit-btns-container__btns-box__btn item-detail__edit-btns-container__btns-box__btn__delete-btn'
   .item-detail__message
     .item-detail__message__message-container
       %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -70,9 +70,9 @@
       %span.item-detail__top-container__price-box__tax &#040;税込&#041;
       %span.item-detail__top-container__price-box__shipping-fee 送料込み
     - unless @user == current_user
-      - if @item.status == "sale"
+      - if @item.sale?
         = link_to '購入画面に進む', buy_item_path, class: 'item-detail__top-container__buy-btn'
-      - elsif @item.status == "sold"
+      - elsif @item.sold?
         .item-detail__top-container__buy-btn.item-detail__top-container__buy-btn__disabled
           売り切れました
     .item-detail__top-container__item-description

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -92,7 +92,7 @@
         =link_to "https://www.mercari.com/jp/safe/description/", target: '_blank' do
           =fa_icon 'lock'
           %span あんしん・あんぜんへの取り組み
-  - if @user == current_user
+  - if @user == current_user && @item.status != "sold"
     .item-detail__edit-btns-container
       .item-detail__edit-btns-container__btns-box
         =link_to '商品の編集', edit_item_path, class: 'item-detail__edit-btns-container__btns-box__btn item-detail__edit-btns-container__btns-box__btn__edit-btn'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -68,6 +68,9 @@
       %span.item-detail__top-container__price-box__shipping-fee 送料込み
     - if @item.status == "sale"
       = link_to '購入画面に進む', buy_item_path, class: 'item-detail__top-container__buy-btn'
+    - elsif @item.status == "sold"
+      .item-detail__top-container__buy-btn.item-detail__top-container__buy-btn__disabled
+        売り切れました
     .item-detail__top-container__item-description
       %p
         =@item.description

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -66,7 +66,8 @@
         = @item.price.to_s(:delimited)
       %span.item-detail__top-container__price-box__tax &#040;税込&#041;
       %span.item-detail__top-container__price-box__shipping-fee 送料込み
-    = link_to '購入画面に進む', buy_item_path, class: 'item-detail__top-container__buy-btn'
+    - if @item.status == "sale"
+      = link_to '購入画面に進む', buy_item_path, class: 'item-detail__top-container__buy-btn'
     .item-detail__top-container__item-description
       %p
         =@item.description

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -66,6 +66,7 @@
         = @item.price.to_s(:delimited)
       %span.item-detail__top-container__price-box__tax &#040;税込&#041;
       %span.item-detail__top-container__price-box__shipping-fee 送料込み
+    = link_to '購入画面に進む', buy_item_path, class: 'item-detail__top-container__buy-btn'
     .item-detail__top-container__item-description
       %p
         =@item.description

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -89,12 +89,13 @@
         =link_to "https://www.mercari.com/jp/safe/description/", target: '_blank' do
           =fa_icon 'lock'
           %span あんしん・あんぜんへの取り組み
-  .item-detail__edit-btns-container
-    .item-detail__edit-btns-container__btns-box
-      =link_to '商品の編集', edit_item_path, class: 'item-detail__edit-btns-container__btns-box__btn item-detail__edit-btns-container__btns-box__btn__edit-btn'
-      %p.item-detail__edit-btns-container__btns-box__text or
-      =link_to '出品を一旦停止する', '', class: 'item-detail__edit-btns-container__btns-box__btn item-detail__edit-btns-container__btns-box__btn__stop-btn'
-      =link_to 'この商品を削除する', item_path, method: :delete, class: 'item-detail__edit-btns-container__btns-box__btn item-detail__edit-btns-container__btns-box__btn__delete-btn'
+  - if @user == current_user
+    .item-detail__edit-btns-container
+      .item-detail__edit-btns-container__btns-box
+        =link_to '商品の編集', edit_item_path, class: 'item-detail__edit-btns-container__btns-box__btn item-detail__edit-btns-container__btns-box__btn__edit-btn'
+        %p.item-detail__edit-btns-container__btns-box__text or
+        =link_to '出品を一旦停止する', '', class: 'item-detail__edit-btns-container__btns-box__btn item-detail__edit-btns-container__btns-box__btn__stop-btn'
+        =link_to 'この商品を削除する', item_path, method: :delete, class: 'item-detail__edit-btns-container__btns-box__btn item-detail__edit-btns-container__btns-box__btn__delete-btn'
   .item-detail__message
     .item-detail__message__message-container
       %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。


### PR DESCRIPTION
# What
- 各商品について、以下の条件で購入、編集等のボタンを表示

（１）ユーザーの出品アイテムの場合
「購入画面に進む」又は「売り切れました」ボタンは非表示
編集等のボタンを表示
https://gyazo.com/ca7212a2f7925886d145b882d24b6b32

（２）他人の出品アイテムの場合
（２−１）販売中の場合
「購入画面に進む」ボタンを表示
https://gyazo.com/a9a8e41dd0bbe58c16f5ac8b5f7a39a6

（２−２）売り切れの場合
「売り切れました」ボタンを表示
https://gyazo.com/6e115d45e6ef90a3e6b8af3cc1a266c0

- 各商品について、売却済の場合、メイン画像に「SOLD」を表示
- 関連商品について、売却済の場合、リンク画像に「SOLD」を表示
https://gyazo.com/5e9b55e8922d2ec1fec7809afdddac17

# Why
- 出品者が商品の出品状態を変更できるようにするため
- 出品者以外が商品を購入できるようにするため
- 商品が販売中か否かを分かりやすく示すため
