### PR TITLE
Add items#create page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,7 +58,9 @@
 // item/done
 @import 'module/items/done';
 
-// items/delete_confirmation
-@import 'module/items/delete_confirmation';
+// items/create
+// items/update
+// items/delete_confirmation 
+@import 'module/items/complete_action';
 // items/edit
 @import 'module/items/edit';

--- a/app/assets/stylesheets/module/items/_complete_action.scss
+++ b/app/assets/stylesheets/module/items/_complete_action.scss
@@ -1,4 +1,4 @@
-.delete{
+.complete-action{
   width: 100%;
   height: 100vh;
   background-color: $white;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -40,9 +40,7 @@ class ItemsController < ApplicationController
       images_params[:image].each do |img|
         @item.images.build(image: img)
       end
-      if @item.save
-        redirect_to root_path
-      else
+      unless @item.save
         flash.now[:alert] = "必要事項を入力してください"
         render new_item_path
       end

--- a/app/views/items/create.html.haml
+++ b/app/views/items/create.html.haml
@@ -1,0 +1,6 @@
+.complete-action
+  %p 商品が出品されました！
+
+  .btn-box
+    = link_to('商品詳細へ', item_path(@item), class: 'mypage-btn')
+    = link_to('トップページ', root_path, class: 'back-btn')

--- a/app/views/items/delete_confirmation.html.haml
+++ b/app/views/items/delete_confirmation.html.haml
@@ -1,4 +1,4 @@
-.delete
+.complete-action
   %p 商品が削除されました！
   .btn-box
     = link_to('マイページへ', users_path, class: 'mypage-btn')

--- a/app/views/items/update.html.haml
+++ b/app/views/items/update.html.haml
@@ -1,4 +1,4 @@
-.delete
+.complete-action
   %p 商品情報が更新されました！
 
   .btn-box


### PR DESCRIPTION
# what
- 商品出品後の画面(items#create)ページを作成
- 共通のCSSを利用するため、ファイル名やclass名を変更

# why
従前：商品出品完了後に、トップページ画面を表示する設定をしていた。  
↑これでは、出品できたかどうかわからないため、新たにページを作成