### PR TITLE
Modify items#create and update

### DIFF
--- a/app/assets/stylesheets/module/items/_edit.scss
+++ b/app/assets/stylesheets/module/items/_edit.scss
@@ -163,7 +163,7 @@
               font-weight: 600;
             }
             .required {
-              background-color: $red;
+              background-color: $gray;
               @include require;
             }
             &__form {

--- a/app/assets/stylesheets/module/items/_new.scss
+++ b/app/assets/stylesheets/module/items/_new.scss
@@ -162,7 +162,7 @@
               font-weight: 600;
             }
             .required {
-              background-color: $red;
+              background-color: $gray;
               @include require;
             }
             &__form {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,22 +28,15 @@ class ItemsController < ApplicationController
   end
 
   def new
+    10.times { @item.images.build }
   end
 
   def create
-    if params[:image] == nil
-      flash.now[:alert] = "必須事項を入力してください"
-      render new_item_path
-    else
-      @brand = Brand.where(name: brand_params[:name]).first_or_create
-      @item = Item.new(items_params)
-      images_params[:image].each do |img|
-        @item.images.build(image: img)
-      end
-      unless @item.save
-        flash.now[:alert] = "必要事項を入力してください"
-        render new_item_path
-      end
+    @brand = Brand.where(name: brand_params[:name]).first_or_create
+    @item = Item.new(items_params)
+    unless @item.save
+      flash[:alert] = @item.errors.full_messages
+      redirect_to new_item_path
     end
   end
 
@@ -115,6 +108,8 @@ class ItemsController < ApplicationController
     @grandchildren_categories = @item.category.siblings
     @children_categories = @item.category.parent.siblings
     @fee = @item.price * 0.1
+    num = 10 - @item.images.length
+    num.times {@item.images.build}
   end
 
   def update
@@ -145,6 +140,7 @@ class ItemsController < ApplicationController
       :prefecture_from, 
       :shipping_date, 
       :price,
+      images_attributes: [:image]
     ).merge(brand_id: @brand.id, seller_id: current_user.id, status: 0)
   end
 
@@ -162,10 +158,6 @@ class ItemsController < ApplicationController
       :price,
       images_attributes: [:image, :id, :_destroy]
       ).merge(brand_id: @brand.id)
-  end
-
-  def images_params
-    params.require(:image).permit({image: []}, item_id: @item.id)
   end
 
   def set_parents_categories

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,9 +2,15 @@ class Item < ApplicationRecord
   #アソシエーション
   belongs_to :user
   has_many :images, dependent: :destroy
-  accepts_nested_attributes_for :images, allow_destroy: true
+  accepts_nested_attributes_for :images, allow_destroy: true, reject_if: :reject_image_blank
   belongs_to :brand
   belongs_to :category
+
+  # 空白のimages_attributesを削除
+  def reject_image_blank(attributes)
+    attributes['id'].blank? && attributes['image'].blank?
+  end
+
 
   # enumの定義
   enum size: { XXS: 0, XS: 1, S: 2, M: 3, L: 4, XL: 5, XXL: 6, XXXL: 7, XXXXXL: 8, free_size: 9 }

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -22,7 +22,7 @@
                   %p.upload-form__num 
                   = fi.label :image, class: 'upload-form__select-btn', for: "image#{i}" do
                     = fi.file_field :image, class: 'upload-form__select-btn--input_tag', id: "image#{i}"
-                    変更
+                    選択
                   .upload-form__remove-btn
                     = fi.check_box :_destroy
                     削除
@@ -46,7 +46,7 @@
                 = f.collection_select :category_id, @grandchildren_categories, :id, :name, {prompt: "---"}, {class: 'form-box', id: 'grandchildren_category'}
             .size
               = f.label :size, 'サイズ', class: 'size__name'
-              %span.required 必須
+              %span.required 任意
               .size__form
                 = f.select :size, Item.sizes.keys.map { |k| [t("enums.item.size.#{k}"), k]}, { prompt: "---" }, {class: 'form-box'}
             .brand

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -6,7 +6,8 @@
     %h2.title 商品の情報を入力
     - if flash[:alert].present?
       %ul.error-alert
-        %li.error-alert__list #{flash[:alert]}
+        - flash[:alert].each do |message|
+          %li.error-alert__list #{message}
     .form
       = form_with(model: @item, local: true, multipart: true) do |f|
         .image
@@ -14,78 +15,16 @@
             出品画像
             %span.required 必須
           %p.image__attention 最大10枚までアップロードできます（選択ボタンを押してください）
-          = fields_for @image do |fi|
-            %ul.image__upload
-              %li.upload-form
-                %p.upload-form__num ①
-                = fi.label :image, class: 'upload-form__select-btn', for: 'image0' do
-                  = fi.file_field :image, multiple: true, class: 'upload-form__select-btn--input_tag', id:'image0'
-                  選択
-                #image0_rmv.upload-form__remove-btn 削除
-                #image0_name.upload-form__name 
-              %li.upload-form
-                %p.upload-form__num ②
-                = fi.label :image, class: 'upload-form__select-btn', for: 'image1' do
-                  = fi.file_field :image, multiple: true, class: 'upload-form__select-btn--input_tag', id: 'image1'
-                  選択
-                #image1_rmv.upload-form__remove-btn 削除
-                #image1_name.upload-form__name
-              %li.upload-form
-                %p.upload-form__num ③
-                = fi.label :image, class: 'upload-form__select-btn', for: 'image2' do
-                  = fi.file_field :image, multiple: true, class: 'upload-form__select-btn--input_tag', id: 'image2'
-                  選択
-                #image2_rmv.upload-form__remove-btn 削除
-                #image2_name.upload-form__name
-              %li.upload-form
-                %p.upload-form__num ④ 
-                = fi.label :image, class: 'upload-form__select-btn', for: 'image3' do
-                  = fi.file_field :image, multiple: true, class: 'upload-form__select-btn--input_tag', id: 'image3'
-                  選択
-                #image3_rmv.upload-form__remove-btn 削除
-                #image3_name.upload-form__name
-              %li.upload-form
-                %p.upload-form__num ⑤ 
-                = fi.label :image, class: 'upload-form__select-btn', for: 'image4' do
-                  = fi.file_field :image, multiple: true, class: 'upload-form__select-btn--input_tag', id: 'image4'
-                  選択
-                #image4_rmv.upload-form__remove-btn 削除
-                #image4_name.upload-form__name
-              %li.upload-form
-                %p.upload-form__num ⑥
-                = fi.label :image, class: 'upload-form__select-btn', for: 'image5' do
-                  = fi.file_field :image, multiple: true, class: 'upload-form__select-btn--input_tag', id: 'image5'
-                  選択
-                #image5_rmv.upload-form__remove-btn 削除
-                #image5_name.upload-form__name
-              %li.upload-form
-                %p.upload-form__num ⑦
-                = fi.label :image, class: 'upload-form__select-btn', for: 'image6' do
-                  = fi.file_field :image, multiple: true, class: 'upload-form__select-btn--input_tag', id: 'image6'
-                  選択
-                #image6_rmv.upload-form__remove-btn 削除
-                #image6_name.upload-form__name
-              %li.upload-form
-                %p.upload-form__num ⑧
-                = fi.label :image, class: 'upload-form__select-btn', for: 'image7' do
-                  = fi.file_field :image, multiple: true, class: 'upload-form__select-btn--input_tag', id: 'image7'
-                  選択
-                #image7_rmv.upload-form__remove-btn 削除
-                #image7_name.upload-form__name
-              %li.upload-form
-                %p.upload-form__num ⑨
-                = fi.label :image, class: 'upload-form__select-btn', for: 'image8' do
-                  = fi.file_field :image, multiple: true, class: 'upload-form__select-btn--input_tag', id: 'image8'
-                  選択
-                #image8_rmv.upload-form__remove-btn 削除
-                #image8_name.upload-form__name
-              %li.upload-form
-                %p.upload-form__num ⑩
-                = fi.label :image, class: 'upload-form__select-btn', for: 'image9' do
-                  = fi.file_field :image, multiple: true, class: 'upload-form__select-btn--input_tag', id: 'image9'
-                  選択
-                #image9_rmv.upload-form__remove-btn 削除
-                #image9_name.upload-form__name
+          %ul.image__upload
+            - @item.images.each_with_index do |image, i|
+              = f.fields_for :images, image do |fi|
+                %li.upload-form
+                  %p.upload-form__num
+                  = fi.label :image, class: 'upload-form__select-btn', for: "image#{i}" do
+                    = fi.file_field :image, class: 'upload-form__select-btn--input_tag', id:"image#{i}"
+                    選択
+                  .upload-form__remove-btn{id: "image#{i}_rmv"} 削除
+                  .upload-form__name{id: "image#{i}_name"} 
         .item
           = f.label :name, '商品名', class: 'item__title'
           %span.required 必須
@@ -103,7 +42,7 @@
                 = f.collection_select :category_id, @parents_categories, :id, :name, {prompt: "---"}, {class: 'form-box', id: 'parent_category'}
             .size
               = f.label :size, 'サイズ', class: 'size__name'
-              %span.required 必須
+              %span.required 任意
               .size__form
                 = f.select :size, Item.sizes.keys.map { |k| [t("enums.item.size.#{k}"), k]}, { include_blank: "---", selected: "---" }, {class: 'form-box'}
             .brand


### PR DESCRIPTION
# what
1.  商品出品
 - images_attributesを使用して登録するように変更
 - 入力漏れがあった場合のエラーメッセージを詳細に表示するように変更  
    (従前は、一律で「必須事項を入力してください」)
2. 商品編集
 - 商品画像を追加できるように機能を追加

# why
1. 商品編集時のエラー表示と一致させるため
2. 誰かに買ってもらうため、出品後に商品画像を追加したくなる場面が想定されるため