### PR TITLE
Modify category select-list

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,7 +28,14 @@ class ItemsController < ApplicationController
   end
 
   def new
+    @item = Item.new(flash[:data]) if flash[:data].present?
     10.times { @item.images.build }
+    if @item.category.present?
+      @selected_children_category = @item.category.parent
+      @selected_parents_category = @selected_children_category.parent
+      @grandchildren_categories = @item.category.siblings
+      @children_categories = @item.category.parent.siblings
+    end
   end
 
   def create
@@ -36,6 +43,7 @@ class ItemsController < ApplicationController
     @item = Item.new(items_params)
     unless @item.save
       flash[:alert] = @item.errors.full_messages
+      flash[:data] = Item.new(items_params)
       redirect_to new_item_path
     end
   end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -40,11 +40,14 @@
               %span.required 必須
               .category__form
                 = f.collection_select :category_id, @parents_categories, :id, :name, {prompt: "---"}, {class: 'form-box', id: 'parent_category'}
+                - if @grandchildren_categories.present?
+                  = f.collection_select :category_id, @children_categories, :id, :name, {prompt: "---"}, {class: 'form-box', id: 'children_category'}
+                  = f.collection_select :category_id, @grandchildren_categories, :id, :name, {prompt: "---"}, {class: 'form-box', id: 'grandchildren_category'}
             .size
               = f.label :size, 'サイズ', class: 'size__name'
               %span.required 任意
               .size__form
-                = f.select :size, Item.sizes.keys.map { |k| [t("enums.item.size.#{k}"), k]}, { include_blank: "---", selected: "---" }, {class: 'form-box'}
+                = f.select :size, Item.sizes.keys.map { |k| [t("enums.item.size.#{k}"), k]}, { prompt: "---" }, {class: 'form-box'}
             .brand
               = fields_for @brand do |fb|
                 = fb.label :name, 'ブランド' ,class: 'brand__name'


### PR DESCRIPTION
# What
カテゴリーを３階層選択した場合、バリデーションエラーでredirect_toされても、値を保持するように実装

# why
redirect_to で入力フォームを最初から埋めていくのは、面倒なため