### PR TITLE
Update items#index page

### DIFF
--- a/app/assets/stylesheets/module/items/_index.scss
+++ b/app/assets/stylesheets/module/items/_index.scss
@@ -156,6 +156,7 @@
               overflow: hidden;
               position: relative;
               font-size: 14px;
+              line-height: 14px;
               padding: 12px;
             }
        }


### PR DESCRIPTION
# What
各アイテムのタイトルのフォントを調整
（font-sizeとline-heightを揃えた）

# Why
タイトルが長いアイテムを出品した場合に、２行目のフォントの下半分が欠けてしまう問題を解消するため